### PR TITLE
Use exit code 1 for failure

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -203,5 +203,5 @@ else
   worker.reproduction = opts[:reproduction]
   worker.tags = opts[:tags]
   worker.junit_output = opts[:junit_output]
-  worker.work
+  exit worker.work
 end

--- a/lib/rspecq/formatters/failure_recorder.rb
+++ b/lib/rspecq/formatters/failure_recorder.rb
@@ -36,6 +36,9 @@ module RSpecQ
           # to be picked up by a different worker
           sleep 0.5
           return
+        else
+          # returns nil when hit requeue limit, use exit code 1
+          @queue.exit_code = 1
         end
 
         presenter = RSpec::Core::Formatters::ExceptionPresenter.new(

--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -87,11 +87,13 @@ module RSpecQ
     STATUS_READY = "ready".freeze
 
     attr_reader :redis
+    attr_accessor :exit_code
 
     def initialize(build_id, worker_id, redis_opts)
       @build_id = build_id
       @worker_id = worker_id
       @redis = Redis.new(redis_opts.merge({ id: worker_id, ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }))
+      @exit_code = 0
     end
 
     # NOTE: jobs will be processed from head to tail (lpop)

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -115,7 +115,7 @@ module RSpecQ
         # to `requeue_lost_job` inside the work loop
         update_heartbeat
 
-        return if queue.build_failed_fast?
+        return queue.exit_code if queue.build_failed_fast?
 
         lost = queue.requeue_lost_job
         puts "Requeued lost job: #{lost}" if lost
@@ -125,7 +125,7 @@ module RSpecQ
         job = queue.reserve_job
 
         # build is finished
-        return if job.nil? && queue.exhausted?
+        return queue.exit_code if job.nil? && queue.exhausted?
 
         next if job.nil?
 


### PR DESCRIPTION
When there's a failure (a failed example even after retrying for `max_requeues` times, we want to label it as a "failed" process with exit code 1. As we would with a normal `rspec` run