### PR TITLE
Use exit code 1 for non example error

### DIFF
--- a/lib/rspecq/queue.rb
+++ b/lib/rspecq/queue.rb
@@ -198,6 +198,7 @@ module RSpecQ
     # For errors occured outside of examples (e.g. while loading a spec file)
     def record_non_example_error(job, message)
       @redis.hset(key_errors, job, message)
+      @exit_code = 1
     end
 
     def record_timing(job, duration)


### PR DESCRIPTION
When there's a non example error, we want to label it as a "failed" process with exit code 1. Replicating rspec's `--error-exit-code=1` flag