### PR TITLE
Support multirepo for Redis keys

### DIFF
--- a/bin/rspecq
+++ b/bin/rspecq
@@ -40,6 +40,14 @@ OptionParser.new do |o|
     opts[:worker] = v
   end
 
+  o.on("--org ORG", "Organization name/VCS account name on Git ") do |v|
+    opts[:org_name] = v
+  end
+
+  o.on("--repo REPO", "Project repository name on Git ") do |v|
+    opts[:repo_name] = v
+  end
+
   o.on("--seed SEED", "The RSpec seed. Passing the seed can be helpful in " \
     "many ways i.e reproduction and testing.") do |v|
     opts[:seed] = v
@@ -143,6 +151,8 @@ end.parse!
 
 opts[:build] ||= ENV["RSPECQ_BUILD"]
 opts[:worker] ||= ENV["RSPECQ_WORKER"]
+opts[:org_name] ||= "your_org"
+opts[:repo_name] ||= "your_repo"
 opts[:total_worker] ||= Integer(ENV["RSPECQ_TOTAL_WORKER"] || 64)
 opts[:seed] ||= ENV["RSPECQ_SEED"]
 opts[:redis_host] ||= ENV["RSPECQ_REDIS"] || DEFAULT_REDIS_HOST
@@ -189,6 +199,8 @@ else
   worker = RSpecQ::Worker.new(
     build_id: opts[:build],
     worker_id: opts[:worker],
+    org_name: opts[:org_name],
+    repo_name: opts[:repo_name],
     redis_opts: redis_opts
   )
 

--- a/lib/rspecq/worker.rb
+++ b/lib/rspecq/worker.rb
@@ -77,10 +77,12 @@ module RSpecQ
 
     attr_reader :queue
 
-    def initialize(build_id:, worker_id:, redis_opts:)
+    def initialize(build_id:, worker_id:, org_name:, repo_name:, redis_opts:)
       @build_id = build_id
       @worker_id = worker_id
-      @queue = Queue.new(build_id, worker_id, redis_opts)
+      @org_name = org_name
+      @repo_name = repo_name
+      @queue = Queue.new(build_id, worker_id, org_name, repo_name, redis_opts)
       @fail_fast = 0
       @files_or_dirs_to_run = "spec"
       @populate_timings = false


### PR DESCRIPTION
Using `build_id` as a prefix for majority of the keys might lead to key collision when rspecq is being used on multiple repository (example: repo A is running build with ID `1337` and repo B is running build with ID `1337`, the rspecq on A and B might mutate the same keys). This PR adds a new option to add organization name and repository name as a prefix for the keys.